### PR TITLE
Introduce disposing of CanvasBase (Ids) to prevent calling event handers on disposed canvas base instances

### DIFF
--- a/src/Blazorex/CanvasBase.cs
+++ b/src/Blazorex/CanvasBase.cs
@@ -5,8 +5,10 @@ using System.Threading.Tasks;
 
 namespace Blazorex
 {
-    public class CanvasBase : ComponentBase
+    public class CanvasBase : ComponentBase, IDisposable
     {
+        private bool _disposed = false;
+
         protected override async Task OnInitializedAsync()
         {
             if (this.CanvasManager is null)
@@ -110,5 +112,26 @@ namespace Blazorex
         public IRenderContext RenderContext { get; private set; }
 
         #endregion Properties
+
+        #region Disposing
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    // Call javascript to delete this canvas Id from the _contexts array
+                    await JSRuntime.InvokeVoidAsync("Blazorex.removeContext", Id);
+                }
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }        
+        #endregion Disposing
     }
 }

--- a/src/Blazorex/CanvasBase.cs
+++ b/src/Blazorex/CanvasBase.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Blazorex
 {
-    public class CanvasBase : ComponentBase, IDisposable
+    public class CanvasBase : ComponentBase, IAsyncDisposable
     {
         private bool _disposed = false;
 
@@ -114,24 +114,15 @@ namespace Blazorex
         #endregion Properties
 
         #region Disposing
-        protected virtual void Dispose(bool disposing)
+        public async ValueTask DisposeAsync()
         {
             if (!_disposed)
             {
-                if (disposing)
-                {
-                    // Call javascript to delete this canvas Id from the _contexts array
-                    await JSRuntime.InvokeVoidAsync("Blazorex.removeContext", Id);
-                }
+                // Call javascript to delete this canvas Id from the _contexts array
+                await JSRuntime.InvokeVoidAsync("Blazorex.removeContext", Id);
                 _disposed = true;
             }
         }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }        
         #endregion Disposing
     }
 }

--- a/src/Blazorex/CanvasBase.cs
+++ b/src/Blazorex/CanvasBase.cs
@@ -120,6 +120,8 @@ namespace Blazorex
             {
                 // Call javascript to delete this canvas Id from the _contexts array
                 await JSRuntime.InvokeVoidAsync("Blazorex.removeContext", Id);
+                await JSRuntime.InvokeVoidAsync("Blazorex.initCanvas", Id, managedInstance);
+
                 _disposed = true;
             }
         }

--- a/src/Blazorex/CanvasBase.cs
+++ b/src/Blazorex/CanvasBase.cs
@@ -120,8 +120,7 @@ namespace Blazorex
             {
                 // Call javascript to delete this canvas Id from the _contexts array
                 await JSRuntime.InvokeVoidAsync("Blazorex.removeContext", Id);
-                await JSRuntime.InvokeVoidAsync("Blazorex.initCanvas", Id, managedInstance);
-
+                
                 _disposed = true;
             }
         }

--- a/src/Blazorex/wwwroot/blazorex.js
+++ b/src/Blazorex/wwwroot/blazorex.js
@@ -79,7 +79,16 @@ window.Blazorex = (() => {
         }
 
         return result;
-    };
+    },
+    removeContext = (ctxId) => {
+        const ctx = _contexts[ctxId].context; 
+        if (!ctx){
+            return ;
+        }
+
+        delete _contexts[ctxId]; 
+    }
+    ;
 
     window.onkeyup = (e) => {
         for (let ctx in _contexts) {
@@ -117,3 +126,6 @@ window.Blazorex = (() => {
 })();
 
 window.requestAnimationFrame(Blazorex.onFrameUpdate);
+
+
+

--- a/src/Blazorex/wwwroot/blazorex.js
+++ b/src/Blazorex/wwwroot/blazorex.js
@@ -121,7 +121,8 @@ window.Blazorex = (() => {
         createImageData,
         putImageData,
         processBatch,
-        directCall
+        directCall,
+        removeContext
     };
 })();
 


### PR DESCRIPTION
Implemented changes to two files:

**blazorex.js**, introduce and return a new method called removeContext = (ctxId) => ...

```
removeContext = (ctxId) => {
        const ctx = _contexts[ctxId].context; 
        if (!ctx){
            return ;
        }

        delete _contexts[ctxId]; 
    }
```
 

Also, see **CanvasBase.cs**, included implements for IAsyncDisposable

```
    public class CanvasBase : ComponentBase, IAsyncDisposable

        #region Disposing
        public async ValueTask DisposeAsync()
        {
            if (!_disposed)
            {
                // Call javascript to delete this canvas Id from the _contexts array
                await JSRuntime.InvokeVoidAsync("Blazorex.removeContext", Id);
                
                _disposed = true;
            }
        }
        #endregion Disposing
```

